### PR TITLE
Fixed Typos in Markdowns

### DIFF
--- a/DA43dsMax/instructions/task-4.md
+++ b/DA43dsMax/instructions/task-4.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/DA4ACAD/instructions/task-5.md
+++ b/DA4ACAD/instructions/task-5.md
@@ -13,7 +13,7 @@ There are three Postman Environment Variables you must specify for this task. Th
 2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name the Bucket that stores your files.
 
     **Notes:**  
-    - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+    - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
     - The Bucket name must consist of only lower case characters, the numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_01/instructions/task-2.md
+++ b/ModelDerivative_01/instructions/task-2.md
@@ -1,4 +1,4 @@
-# Task 2 - Upload Source FIle to OSS
+# Task 2 - Upload Source File to OSS
 
 The Object Storage Service (OSS) is a generic Cloud Storage Service that is part of the Forge Data Management API. In this task, you upload the model to translate to OSS. While you can use any model for this purpose, we recommend that you use the file *box.ipt*, which is available in the [*tutorial_data*](../tutorial_data) folder.
 

--- a/ModelDerivative_01/instructions/task-3.md
+++ b/ModelDerivative_01/instructions/task-3.md
@@ -6,7 +6,7 @@ To translate a file, you must kick off a translation job. The translation job pr
 
 ## Start a translation job
 
-For this task, you will use the Base64-encoded URN of the source file. In the previous task, Postman saved this to the variable `t1_ossEncodedSourceFileURN`, which you will use in the newxt request.
+For this task, you will use the Base64-encoded URN of the source file. In the previous task, Postman saved this to the variable `t1_ossEncodedSourceFileURN`, which you will use in the next request.
 
 1. In the Postman sidebar, click **Task 3 - Translate Source File > Create a Translation Job**. The request loads.
 

--- a/ModelDerivative_02/instructions/before_you_begin.md
+++ b/ModelDerivative_02/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_02/instructions/task-2.md
+++ b/ModelDerivative_02/instructions/task-2.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_03/instructions/before_you_begin.md
+++ b/ModelDerivative_03/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_03/instructions/task-2.md
+++ b/ModelDerivative_03/instructions/task-2.md
@@ -17,7 +17,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_04/instructions/before_you_begin.md
+++ b/ModelDerivative_04/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_04/instructions/task-2.md
+++ b/ModelDerivative_04/instructions/task-2.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_05/instructions/before_you_begin.md
+++ b/ModelDerivative_05/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_05/instructions/task-2.md
+++ b/ModelDerivative_05/instructions/task-2.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_06/instructions/before_you_begin.md
+++ b/ModelDerivative_06/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_06/instructions/task-2.md
+++ b/ModelDerivative_06/instructions/task-2.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 

--- a/ModelDerivative_07/instructions/before_you_begin.md
+++ b/ModelDerivative_07/instructions/before_you_begin.md
@@ -2,7 +2,7 @@
 
 ## Import the Postman Collection and Postman environment.
 
-Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or recieve a response.
+Postman Collections are groups of prepopulated HTTP requests. They can also contain scripts that are executed when you send an HTTP request, and/or receive a response.
 
 Postman environments are named configurations that implement environment variables to store values you typically use across many HTTP requests. For example, this Postman Collection stores the Access Token, which is used across most HTTP requests, in a variable named `access_token`.
 

--- a/ModelDerivative_07/instructions/task-2.md
+++ b/ModelDerivative_07/instructions/task-2.md
@@ -13,7 +13,7 @@ In this tutorial, you will use a Postman environment variable named `ossBucketKe
     2. In the **CURRENT VALUE** column, in the **ossBucketKey** row, specify a name for the Bucket that stores your files.
 
         **Notes:**  
-        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you recieve this error, change the value of this variable and try again.
+        - The Bucket name needs to be unique throughout the OSS service. if a Bucket with the name you specified already exists, the system will return a `409` conflict error in step 5. If you receive this error, change the value of this variable and try again.
 
         - The Bucket name must consist of only lower-case characters, numbers 0-9, and the underscore (_) character.
 


### PR DESCRIPTION
Hi,

Noticed a few typos in the documents when running through the tutorial:

- Small typos in first tutorial,
- Changed the remaining `recieve` -> `receive`

Cheers!